### PR TITLE
Warning icon when the user is not logged in

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -207,8 +207,7 @@ class Background {
 
   updateIcon() {
     let icon;
-    if (this.proxyState === PROXY_STATE_INACTIVE ||
-        this.proxyState === PROXY_STATE_UNKNOWN) {
+    if (this.proxyState === PROXY_STATE_INACTIVE) {
       icon = "img/badge_off.png";
     } else if (this.proxyState === PROXY_STATE_ACTIVE) {
       icon = "img/badge_on.png";


### PR DESCRIPTION
I checked this issue with Emanuela. The 'badge off' is shown only when the user disables the proxy.