### PR TITLE
Add doctype, charset, and title to popup.html

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <link rel="stylesheet" href="popup.css" />
-    <title>Firefox Private Network</title>
   </head>
   <body>
     <div id="introHeading">


### PR DESCRIPTION
Should mostly pass linters at https://validator.w3.org/nu/#textarea, https://html5.validator.nu/, and https://htmlhint.io/ (with the exception of the duplicate `id` attribute issue reported in #78).

Fixes #73 