### PR TITLE
Missing button label on Settings view #134

### DIFF
--- a/src/views/settings.js
+++ b/src/views/settings.js
@@ -17,7 +17,7 @@ class ViewSettings extends View {
         <li><a href="TODO">${this.getTranslation("viewSettings-privacyPolicyLink")}</a></li>
         <li><a href="TODO">${this.getTranslation("viewSettings-termsAndConditionsLink")}</a></li>
       </ul>
-      <button class="primary" id="manageAccount">${this.getTranslation("manageAccountButton")}</button>
+      <button class="primary" id="manageAccount">${this.getTranslation("viewSettings-manageAccountButton")}</button>
     `;
   }
 


### PR DESCRIPTION
I asked about the double feature access (button and link). Emanuela would like to have telemetry to know what the user prefers. But, this bug is just about the missing string.