### PR TITLE
Fix ESLint errors

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -62,7 +62,9 @@ class Background {
     try {
       const capitivePortalUrl = new URL(await browser.experiments.proxyutils.getCaptivePortalURL());
       this.captivePortalOrigin = capitivePortalUrl.origin;
-    } catch (e) {}
+    } catch (e) {
+      // ignore
+    }
 
     // Ask the learn more link.
     this.learnMoreUrl = await browser.experiments.proxyutils.formatURL(LEARN_MORE_URL);

--- a/src/experiments/proxyutils/api.js
+++ b/src/experiments/proxyutils/api.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-/* globals ChromeUtils, ExtensionAPI, ExtensionCommon, Services, Ci */
+/* globals ChromeUtils, ExtensionAPI, ExtensionCommon, Services */
 
 "use strict";
 


### PR DESCRIPTION
Current status (down to two warnings):

```sh
$ npm run lint

> secure-proxy@1.0.0 lint /Users/pdehaan/dev/github/mozilla/secure-proxy
> eslint src


/Users/pdehaan/dev/github/mozilla/secure-proxy/src/background.js
  1:1  warning  Unexpected 'todo' comment  no-warning-comments

/Users/pdehaan/dev/github/mozilla/secure-proxy/src/experiments/proxyutils/api.js
  54:5  warning  Unexpected 'todo' comment  no-warning-comments

✖ 2 problems (0 errors, 2 warnings)
```
