### PR TITLE
Use email-first FxA flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -408,9 +408,9 @@
       "dev": true
     },
     "fxa-crypto-relier": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/fxa-crypto-relier/-/fxa-crypto-relier-2.5.0.tgz",
-      "integrity": "sha512-SLXHxWqy/qG+onw+/1K0LuxM/DxjjNg84PT3sU2thW81iL1TdqRhNCQFcxgYtyFzdeIEZRsODpG0Vw/2jpq6Dg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/fxa-crypto-relier/-/fxa-crypto-relier-2.6.0.tgz",
+      "integrity": "sha512-9fZ54WvJZjAq+H2RAK50jmYA+lAuSvHil1+vpu5TDDnNDT50F1I4t+TizY7rXgy8X4ddqd/+zFd9A+rrJHdxHQ==",
       "requires": {
         "base64url": "^3.0.0",
         "node-hkdf": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/mozilla/secure-proxy#readme",
   "dependencies": {
-    "fxa-crypto-relier": "^2.5.0"
+    "fxa-crypto-relier": "^2.6.0"
   },
   "devDependencies": {
     "eslint": "^6.0.1"


### PR DESCRIPTION
Update the fxa-crypto-relier to v2.6.0 which uses
the email-first flow by default instead of
redirecting directly to /signup if no user
is signed in.

fixes #190

<img width="575" alt="Screenshot 2019-07-19 at 18 50 13" src="https://user-images.githubusercontent.com/848085/61554939-15227580-aa56-11e9-8e26-a5955fba5a63.png">


@bakulf - r?