### PR TITLE
Change modal text to 'Tab' rather than 'Site'

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -20,7 +20,7 @@
     "message": "Not Now"
   },
   "injectedModalAcceptButton": {
-    "message": "Turn Off for This Site"
+    "message": "Turn Off for This Tab"
   },
   "viewExemptTab": {
     "message": "Firefox Private Network is off for this tab. Your connection to this site is not secure."


### PR DESCRIPTION
As discussed in #293 we are changing the text to Tab. This is still not confirmed as the correct text but it's better than having it wrong.