### PR TITLE
Move contextual banner to only be used by methods negating enumerateD…

### DIFF
--- a/src/content-script.js
+++ b/src/content-script.js
@@ -62,10 +62,10 @@ const ContentScript = {
 
   overwriteProperties() {
     const overwrittenProperties = new Set([
-      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "getSupportedConstraints", type: "method" },
-      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "enumerateDevices", type: "method" },
-      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "getUserMedia", type: "method" },
-      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "getDisplayMedia", type: "method" },
+      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "getSupportedConstraints", type: "method", potentiallyShowContextBanner: true },
+      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "enumerateDevices", type: "method", potentiallyShowContextBanner: false },
+      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "getUserMedia", type: "method", potentiallyShowContextBanner: true },
+      { originalMethod: null, parentObject: window.navigator.mediaDevices, methodName: "getDisplayMedia", type: "method", potentiallyShowContextBanner: true },
       { originalMethod: null, parentObject: window, methodName: "RTCPeerConnection", type: "object" },
       { originalMethod: null, parentObject: window, methodName: "RTCIceCandidate", type: "object" },
       { originalMethod: null, parentObject: window, methodName: "RTCPeerConnectionStatic", type: "object" },
@@ -81,9 +81,11 @@ const ContentScript = {
         Object.defineProperty(object, property, {
          get: exportFunction(() => {
           if (ContentScript.shouldOverload()) {
-            ContentScript.potentiallyShowContextBanner();
             if (data.type === "method") {
               return exportFunction(() => {
+                if (data.potentiallyShowContextBanner) {
+                  ContentScript.potentiallyShowContextBanner();
+                }
                 return window.wrappedJSObject.Promise.reject(new window.wrappedJSObject.Error("SecurityError"));
               }, window);
             }


### PR DESCRIPTION
…evices. Fixes #347


It seems bing enumerates the device for fingerprinting, despite being something we would probably like to preventy it's not related to the bug so I exempted it and verified web rtc demo sites are still working.