### PR TITLE
Add status text to the browser action. Fixes #367

### DIFF
--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -5,6 +5,16 @@
   "extensionDescription": {
     "message": "A secure, encrypted tunnel to the web to protect yourself everywhere you use Firefox."
   },
+
+  "badgeOnText": {
+    "message": "Firefox Private Network is On"
+  },
+  "badgeOffText": {
+    "message": "Firefox Private Network is Off"
+  },
+  "badgeWarningText": {
+    "message": "Firefox Private Network is inactive"
+  },
     
   "heroProxyOff": {
     "message": "OFF"

--- a/src/background.js
+++ b/src/background.js
@@ -433,18 +433,25 @@ class Background {
   // This updates any tab that doesn't have an exemption
   updateIcon() {
     let icon;
+    let text;
     if (this.proxyState === PROXY_STATE_INACTIVE ||
         this.proxyState === PROXY_STATE_CONNECTING ||
         this.proxyState === PROXY_STATE_OFFLINE) {
       icon = "img/badge_off.svg";
+      text = "badgeOffText";
     } else if (this.proxyState === PROXY_STATE_ACTIVE) {
       icon = "img/badge_on.svg";
+      text = "badgeOnText";
     } else {
       icon = "img/badge_warning.svg";
+      text = "badgeWarningText";
     }
 
     browser.browserAction.setIcon({
       path: icon,
+    });
+    browser.browserAction.setTitle({
+      title: this.getTranslation(text),
     });
   }
 
@@ -453,13 +460,20 @@ class Background {
     log(`updating tab icon: ${tabId}`);
     // default value here is undefined which resets the icon back when it becomes non exempt again
     let path;
+    // default title resets the tab title
+    let title = null;
     if (this.isTabExempt(tabId)) {
+      title = this.getTranslation("badgeWarningText");
       path = "img/badge_warning.svg";
     }
 
     browser.browserAction.setIcon({
       path,
       tabId
+    });
+    browser.browserAction.setTitle({
+      tabId,
+      title
     });
   }
 


### PR DESCRIPTION
@brassy- and @betsymi I added the following label text to the icon here:

When the proxy is on:
"Firefox Private Network is On"

When the proxy is off:
"Firefox Private Network is Off"

When the proxy is off (disconnected or other error states) or disabled for a webrtc tab:
"Firefox Private Network is inactive"

Please raise an issue if this text isn't correct / can be tweaked :)