### PR TITLE
Use env vars to enable the debugging

### DIFF
--- a/src/experiments/proxyutils/api.js
+++ b/src/experiments/proxyutils/api.js
@@ -314,11 +314,13 @@ this.proxyutils = class extends ExtensionAPI {
               context.extension.id,
               "proxyutils.settings",
               () => {
+                const env = Cc["@mozilla.org/process/environment;1"].getService(Ci.nsIEnvironment);
+
                 return {
-                  debuggingEnabled: false,
+                  debuggingEnabled: (env.get("SECURE_PROXY_DEBUG") === "1"),
                   captiveDetect: getStringPrefValue("captivedetect.canonicalURL"),
-                  fxaURL: null,
-                  proxyURL: null,
+                  fxaURL: env.get("SECURE_PROXY_FXAURL"),
+                  proxyURL: env.get("SECURE_PROXY_PROXYURL"),
                 };
               },
               undefined,


### PR DESCRIPTION
Instead of using preferences, I would suggest to use env variables to enable the debugging and to change proxy/fxa endpoints.