### PR TITLE
Proxy disabled for pass-through domains

### DIFF
--- a/src/background/main.js
+++ b/src/background/main.js
@@ -309,6 +309,8 @@ class Main {
     if (hasChanged) {
       await this.ui.update();
     }
+
+    await this.net.checkProxyPassthrough();
   }
 
   syncPanelShown() {

--- a/src/experiments/proxyutils/api.js
+++ b/src/experiments/proxyutils/api.js
@@ -336,8 +336,10 @@ this.proxyutils = class extends ExtensionAPI {
             register: fire => {
               let observer = _ => fire.async();
               Services.prefs.addObserver("network.proxy.type", observer);
+              Services.prefs.addObserver("network.proxy.no_proxies_on", observer);
               return () => {
                 Services.prefs.removeObserver("network.proxy.type", observer);
+                Services.prefs.removeObserver("network.proxy.no_proxies_on", observer);
               };
             }
           }).api(),


### PR DESCRIPTION
This is not integrated with the content-script and the webRTC. It's a quick workaround to allow the user to disable domains. For 0.7, this should be sufficient. Feedback?