### PR TITLE
add capability to receive and transmit fxa-flow-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/mozilla/secure-proxy#readme",
   "dependencies": {
-    "fxa-crypto-relier": "^2.6.0"
+    "fxa-crypto-relier": "^2.7.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.2",

--- a/src/background/fxa.js
+++ b/src/background/fxa.js
@@ -37,6 +37,7 @@ export class FxAUtils extends Component {
 
   async init(prefs) {
     this.proxyURL = await ConfigUtils.getProxyURL();
+    this.fxaFlowParams = await StorageUtils.getFxaFlowParams();
 
     await this.wellKnownData.init(prefs);
 
@@ -263,6 +264,8 @@ export class FxAUtils extends Component {
         // eslint-disable-next-line verify-await/check
         redirectUri: browser.identity.getRedirectURL(),
         scopes: [FXA_PROFILE_SCOPE, FXA_PROXY_SCOPE],
+        // Spread in FxA flow metrics if we have them
+        ...this.fxaFlowParams,
         // We have our well-known-data cache, let's use it.
         ensureOpenIDConfiguration: _ => this.wellKnownData.openID(),
       });

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -68,6 +68,10 @@ export const StorageUtils = {
     await browser.storage.local.set({lastUsageDays});
   },
 
+  async getFxaFlowParams() {
+    return this.getStorageKey("fxaFlowParams");
+  },
+
   async getStorageKey(key) {
     let data = await browser.storage.local.get([key]);
     return data[key];

--- a/src/content/fetch-fxa-flow-params.js
+++ b/src/content/fetch-fxa-flow-params.js
@@ -1,0 +1,34 @@
+// these three keys help FxA track users from an entrypoint
+// through a conversion funnel.
+// For the best possible understanding of our flow, we fetch
+// these keys from the firefox private network site
+const REQUIRED_KEYS = ["deviceId", "flowBeginTime", "flowId"];
+
+async function getFxaFlowFromSite() {
+  return window.localStorage.getItem("flowInfo");
+}
+
+// set params to storage if valid
+// if not just set an empty object
+async function setFxaFlowParams(data) {
+  const fxaFlowParams = await parse(data);
+  if (await validate(data)) {
+    await browser.storage.local.set({fxaFlowParams});
+  } else {
+    await browser.storage.local.set({fxaFlowParams: {}});
+  }
+}
+
+async function parse(data) {
+  return JSON.parse(data);
+}
+
+// validate everything by making sure
+// all of the required keys are present
+async function validate(data) {
+  return REQUIRED_KEYS.every(key => {
+    return Object.prototype.hasOwnProperty.call(data, key);
+  });
+}
+
+getFxaFlowFromSite().then(res => setFxaFlowParams(res));

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -63,6 +63,10 @@
       "js": ["commons/utils.js", "commons/template.js", "content/content-script.js"],
       "css": ["content/content-modal.css"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["https://private-network.firefox.com/"],
+      "js": ["content/fetch-fxa-flow-params.js"]
     }
   ]
 }


### PR DESCRIPTION
This patch gets some json out of the firefox private network's local storage, parses it, and passes it into the `launchWebExtension` flow of the fxaCryptoRelier.

We do this in order to better track the conversion funnel through FxA