### PR TITLE
#570, set proxy.onRequest callback only when necessary

### DIFF
--- a/src/background/component.js
+++ b/src/background/component.js
@@ -23,4 +23,12 @@ export class Component {
   setProxyState(proxyState) {
     this.cachedProxyState = proxyState;
   }
+
+  pushProxyRequestCallback() {
+    this.receiver.pushProxyRequestCallback();
+  }
+
+  popProxyRequestCallback() {
+    this.receiver.popProxyRequestCallback();
+  }
 }

--- a/src/background/connection.js
+++ b/src/background/connection.js
@@ -1,14 +1,17 @@
 const CONNECTION_TIMEOUT = 20000; // 20 secs.
 
 export class ConnectionTester {
-  static run() {
+  static run(component) {
     log("executing a fetch to check the connection");
 
     return new Promise((resolve, reject) => {
+      // Make sure to go through the proxy
+      component.pushProxyRequestCallback();
+
       setTimeout(_ => reject(), CONNECTION_TIMEOUT);
 
       // eslint-disable-next-line verify-await/check
-      fetch(CONNECTING_HTTP_REQUEST, { cache: "no-cache"}).
+      fetch(CONNECTING_HTTP_REQUEST, { cache: "no-cache" }).
         then(r => {
           if (r.status === 200) {
             // eslint-disable-next-line verify-await/check
@@ -23,6 +26,10 @@ export class ConnectionTester {
           // eslint-disable-next-line verify-await/check
           reject();
         });
+    }).then(_ => {
+      component.popProxyRequestCallback();
+    }, _ => {
+      component.popProxyRequestCallback();
     });
   }
 }

--- a/src/background/main.js
+++ b/src/background/main.js
@@ -167,7 +167,7 @@ class Main {
 
   async testProxyConnection() {
     try {
-      await ConnectionTester.run();
+      await ConnectionTester.run(this);
 
       this.setProxyState(PROXY_STATE_ACTIVE);
 
@@ -457,6 +457,14 @@ class Main {
   registerObserver(observer) {
     // eslint-disable-next-line verify-await/check
     this.observers.add(observer);
+  }
+
+  pushProxyRequestCallback() {
+    this.net.pushProxyRequestCallback();
+  }
+
+  popProxyRequestCallback() {
+    this.net.popProxyRequestCallback();
   }
 }
 

--- a/src/background/network.js
+++ b/src/background/network.js
@@ -18,10 +18,15 @@ export class Network extends Component {
 
     this.proxyPassthrough = new Set();
 
-    // Proxy configuration
-    browser.proxy.onRequest.addListener(requestInfo => {
-      return this.proxyRequestCallback(requestInfo);
-    }, {urls: ["<all_urls>"]});
+    // Proxy configuration is activated only when setProxyState callback 
+    // indicates a state we would allow proxying for content requests.
+    this.requestListner = null;
+    // We may need to force the callback for e.g. connection testing.
+    // This counter > 0 allows adding the callback regardless of the current
+    // proxy state.
+    this.pushProxyRequestCallbackCounter = 0;
+    // Call now, early at the startup stage, to not cause any hypotetical leaks.
+    this.reconfigureProxyRequestCallback();
 
     // Handle header errors before we render the response
     browser.webRequest.onHeadersReceived.addListener(async details => {
@@ -80,6 +85,57 @@ export class Network extends Component {
     await this.checkProxyPassthrough();
   }
 
+  pushProxyRequestCallback() {
+    ++this.pushProxyRequestCallbackCounter;
+    this.reconfigureProxyRequestCallback();
+  }
+
+  popProxyRequestCallback() {
+    --this.pushProxyRequestCallbackCounter;
+    this.reconfigureProxyRequestCallback();
+  }
+
+  setProxyState(proxyState) {
+    super.setProxyState(proxyState);
+    this.reconfigureProxyRequestCallback();
+  }
+
+  /**
+   * Reflect changes to states affecting the decision 
+   * whether proxy.onRequest should be set or not.
+   */
+  reconfigureProxyRequestCallback() {
+    log(`proxy.onRequest reconfiguration, state=${this.cachedProxyState}, push count=${this.pushProxyRequestCallbackCounter}`);
+    
+    if (this.shouldProxyInCurrentState() || this.pushProxyRequestCallbackCounter) {
+      this.activateProxyRequestCallback();
+    } else { 
+      this.deactivateProxyRequestCallback();
+    }
+  }
+
+  activateProxyRequestCallback() {
+    if (!this.requestListner) {
+      this.requestListner = requestInfo => {
+        return this.proxyRequestCallback(requestInfo);
+      };
+      browser.proxy.onRequest.addListener(this.requestListner, { urls: ["<all_urls>"] });
+      log("proxy.onRequest listener has been added");
+    } else {
+      log("proxy.onRequest listener remains added");
+    }
+  }
+
+  deactivateProxyRequestCallback() {
+    if (this.requestListner) {
+      browser.proxy.onRequest.removeListener(this.requestListner);
+      this.requestListner = null;
+      log("proxy.onRequest listener has been removed");
+    } else {
+      log("proxy.onRequest listener remains not-added");
+    }
+  }
+
   async proxyRequestCallback(requestInfo) {
     // eslint-disable-next-line verify-await/check
     let shouldProxyRequest = this.shouldProxyRequest(requestInfo);
@@ -134,6 +190,26 @@ export class Network extends Component {
   }
 
   /**
+   * We want to continue the sending of requests to the proxy even if we
+   * receive errors, in order to avoid exposing the IP when something goes
+   * wrong.
+   *
+   * This also affects whether we set or not the proxy.onRequest callback.
+   */
+  shouldProxyInCurrentState() {
+    if (this.cachedProxyState === PROXY_STATE_LOADING ||
+        this.cachedProxyState === PROXY_STATE_UNAUTHENTICATED ||
+        this.cachedProxyState === PROXY_STATE_AUTHFAILURE ||
+        this.cachedProxyState === PROXY_STATE_INACTIVE ||
+        this.cachedProxyState === PROXY_STATE_CONNECTING ||
+        this.cachedProxyState === PROXY_STATE_OTHERINUSE) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Decides if we should be proxying the request.
    * Returns true if the request should be proxied
    * Returns null if the request is internal and shouldn't count.
@@ -181,15 +257,7 @@ export class Network extends Component {
       return true;
     }
 
-    // We want to continue the sending of requests to the proxy even if we
-    // receive errors, in order to avoid exposing the IP when something goes
-    // wrong.
-    if (this.cachedProxyState === PROXY_STATE_LOADING ||
-        this.cachedProxyState === PROXY_STATE_UNAUTHENTICATED ||
-        this.cachedProxyState === PROXY_STATE_AUTHFAILURE ||
-        this.cachedProxyState === PROXY_STATE_INACTIVE ||
-        this.cachedProxyState === PROXY_STATE_CONNECTING ||
-        this.cachedProxyState === PROXY_STATE_OTHERINUSE) {
+    if (!this.shouldProxyInCurrentState()) {
       return false;
     }
 

--- a/src/background/offline.js
+++ b/src/background/offline.js
@@ -37,7 +37,7 @@ export class OfflineManager extends Component {
     this.timeoutId = 0;
 
     try {
-      await ConnectionTester.run();
+      await ConnectionTester.run(this);
       await this.sendMessage("onlineDetected");
     } catch (e) {
       log("We are still offline");

--- a/src/background/proxyDownChecker.js
+++ b/src/background/proxyDownChecker.js
@@ -77,7 +77,7 @@ export class ProxyDownChecker extends Component {
       new Promise((resolve, reject) => {
         // We want to resolve in case of failure!
         // eslint-disable-next-line verify-await/check
-        ConnectionTester.run().then(reject, resolve);
+        ConnectionTester.run(this).then(reject, resolve);
       }),
 
       // Here a request that doesn't go through the proxy.

--- a/src/tests/background/tester.js
+++ b/src/tests/background/tester.js
@@ -35,7 +35,7 @@ const tests = [
 
 async function testWellKnownData() {
   const wkd = new WellKnownData();
-  wkd.init({value: {}});
+  await wkd.init({value: {}});
 
   Tester.is(wkd.hasWellKnownData(), false, "No data initially");
   Tester.is(wkd.isAuthUrl("wow"), false, "IsAuthUrl works also without data");
@@ -97,9 +97,9 @@ async function testSurvey() {
   Tester.is((await StorageUtils.getLastUsageDays()).count, 1, "Last usage days: 1");
 }
 
-async function testConnectionTester() {
+async function testConnectionTester(m) {
   try {
-    await ConnectionTester.run();
+    await ConnectionTester.run(m);
     Tester.is(false, false, "This should not be resolved!");
   } catch (e) {
     Tester.is(true, true, "ConnectionTester rejects the operation if the proxy is down");


### PR DESCRIPTION
I use the states as listed [here](https://github.com/mozilla/secure-proxy/blob/ca2c85fb9dfea809ac5fad36e73b5394fb58b3ea/src/background/network.js#L187-L192) for which we don't proxy content requests anyway.  There is the exception of the [test request](https://github.com/mozilla/secure-proxy/blob/ca2c85fb9dfea809ac5fad36e73b5394fb58b3ea/src/background/network.js#L180) which is made from only [one place](https://github.com/mozilla/secure-proxy/blob/ca2c85fb9dfea809ac5fad36e73b5394fb58b3ea/src/background/connection.js#L11).  For that case I invented a "push" and "pop" api that forces usage of the proxy.onRequest callback while this testing fetch is in progress (please double check my promise-fu ;))

Tests updated (made work) and ran.  I had a chance to manually test various scenarios, including token expiration, all seems to work well.
