### PR TITLE
Log an explicit telemetry event for 502 errors #837

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -94,6 +94,7 @@ The **methods** are:
 1. `networking` fires when there is a proxy network error. **objects**:
    1. `407`: a 407 error code has been received. This error is received when the proxy receives an invalid/expired token.
    1. `429`: the proxy returns 429 when the user is abusing of the service. The concept of "abuse" has not been defined yet.
+   1. `502`: the proxy returns 502. We want to track this error.
    1. `connecting`: the proxy is unreachable during the connecting phase.
    1. `proxyDown`: the proxy seems unreachable.
 1. `state` fires when the proxy state changes

--- a/src/background/network.js
+++ b/src/background/network.js
@@ -491,9 +491,15 @@ export class Network extends Component {
       return true;
     }
 
+    if (errorStatus === "NS_ERROR_PROXY_BAD_GATEWAY") {
+      this.syncSendMessage("telemetryEvent", { category: "networking", event: "502" });
+      // We don't want to dispatch a proxyGenericError here. We let
+      // NetworkErrorCounter to do it if needed.
+      return true;
+    }
+
     if (errorStatus === "NS_ERROR_PROXY_CONNECTION_REFUSED" ||
         errorStatus === "NS_ERROR_UNKNOWN_PROXY_HOST" ||
-        errorStatus === "NS_ERROR_PROXY_BAD_GATEWAY" ||
         errorStatus === "NS_ERROR_PROXY_GATEWAY_TIMEOUT") {
       await this.sendMessage("proxyGenericError");
       return true;

--- a/src/background/telemetry.js
+++ b/src/background/telemetry.js
@@ -24,7 +24,7 @@ const TELEMETRY_EVENTS = {
   },
   "networkingEvents": {
     methods: [ "networking" ],
-    objects: [ "407", "429", "connecting", "proxyDown" ],
+    objects: [ "407", "429", "502", "connecting", "proxyDown" ],
     extra_keys: [],
     record_on_release: true,
   },


### PR DESCRIPTION
Talking with the necko team, 502 should not be treated so aggressively. We should just disable the proxy is we have too many errors in a defined time window and that is already implemented by NetworkErrorCounter.